### PR TITLE
shrink zgram widths

### DIFF
--- a/frontend/client/components/zgram_component.ts
+++ b/frontend/client/components/zgram_component.ts
@@ -28,7 +28,7 @@ export const zgramComponent = {
     },
     template: `
       <div class="row">
-      <div class="col-8"
+      <div class="col-12"
            v-if="!zg.stronglyHidden" v-on:mouseenter="zg.mouseenter()" v-on:mouseleave="zg.mouseleave()">
         <zgram-header-component :zg="zg">
         </zgram-header-component>

--- a/frontend/client/components/zgram_component.ts
+++ b/frontend/client/components/zgram_component.ts
@@ -27,13 +27,17 @@ export const zgramComponent = {
         zg: ZgramViewModel
     },
     template: `
-<div v-if="!zg.stronglyHidden" v-on:mouseenter="zg.mouseenter()" v-on:mouseleave="zg.mouseleave()">
-<zgram-header-component :zg="zg">
-</zgram-header-component>
-<zgram-body-component :zg="zg">
-</zgram-body-component>
-<zgram-footer-component :zg="zg">
-</zgram-footer-component>
-</div>
+      <div class="row">
+      annoying
+      <div class="col-8"
+           v-if="!zg.stronglyHidden" v-on:mouseenter="zg.mouseenter()" v-on:mouseleave="zg.mouseleave()">
+        <zgram-header-component :zg="zg">
+        </zgram-header-component>
+        <zgram-body-component :zg="zg">
+        </zgram-body-component>
+        <zgram-footer-component :zg="zg">
+        </zgram-footer-component>
+      </div>
+      </div>
     `
 }

--- a/frontend/client/components/zgram_component.ts
+++ b/frontend/client/components/zgram_component.ts
@@ -32,8 +32,16 @@ export const zgramComponent = {
            v-if="!zg.stronglyHidden" v-on:mouseenter="zg.mouseenter()" v-on:mouseleave="zg.mouseleave()">
         <zgram-header-component :zg="zg">
         </zgram-header-component>
+      </div>
+      </div>
+      <div class="row">
+      <div class="col-8">
         <zgram-body-component :zg="zg">
         </zgram-body-component>
+      </div>
+      </div>
+      <div class="row">
+      <div class="col-12">
         <zgram-footer-component :zg="zg">
         </zgram-footer-component>
       </div>

--- a/frontend/client/components/zgram_component.ts
+++ b/frontend/client/components/zgram_component.ts
@@ -28,7 +28,6 @@ export const zgramComponent = {
     },
     template: `
       <div class="row">
-      annoying
       <div class="col-8"
            v-if="!zg.stronglyHidden" v-on:mouseenter="zg.mouseenter()" v-on:mouseleave="zg.mouseleave()">
         <zgram-header-component :zg="zg">

--- a/frontend/client/static/chat.html
+++ b/frontend/client/static/chat.html
@@ -174,7 +174,7 @@
     The zgrams section. Shows previous zgrams, then the zgrams, then a (usually-absent) compose area,
     then the subsequent zgrams.
     --------------------------------------------------------------------------------------------------->
-    <div class="container-lg">
+    <div class="container">
         <stream-status-component :self="state.frontStreamStatus">
         </stream-status-component>
         <hr>

--- a/frontend/client/static/chat.html
+++ b/frontend/client/static/chat.html
@@ -174,7 +174,7 @@
     The zgrams section. Shows previous zgrams, then the zgrams, then a (usually-absent) compose area,
     then the subsequent zgrams.
     --------------------------------------------------------------------------------------------------->
-    <div class="container-fluid">
+    <div class="container-lg">
         <stream-status-component :self="state.frontStreamStatus">
         </stream-status-component>
         <hr>

--- a/frontend/client/static/chat.html
+++ b/frontend/client/static/chat.html
@@ -174,7 +174,7 @@
     The zgrams section. Shows previous zgrams, then the zgrams, then a (usually-absent) compose area,
     then the subsequent zgrams.
     --------------------------------------------------------------------------------------------------->
-    <div class="container">
+    <div class="container-fluid">
         <stream-status-component :self="state.frontStreamStatus">
         </stream-status-component>
         <hr>


### PR DESCRIPTION
The zgram header and footer material stretch across the whole width of the browser.
But the body text will only stretch 3/4 of the way across.