### PR TITLE
Fix 'not' logic

### DIFF
--- a/backend/include/public/z2kplus/backend/coordinator/subscription.h
+++ b/backend/include/public/z2kplus/backend/coordinator/subscription.h
@@ -96,11 +96,11 @@ class Subscription {
 
 public:
   static bool tryCreate(const ConsolidatedIndex &index, std::shared_ptr<Profile> profile,
-      std::unique_ptr<ZgramIterator> &&query, const SearchOrigin &start, size_t pageSize,
+      std::string humanReadableText, std::unique_ptr<ZgramIterator> &&query, const SearchOrigin &start, size_t pageSize,
       size_t queryMargin, std::shared_ptr<Subscription> *result, const FailFrame &ff);
 
   Subscription(Private, subscriptionId_t id, std::shared_ptr<Profile> &&profile,
-      std::unique_ptr<ZgramIterator> &&query, size_t pageSize, size_t queryMargin,
+      std::string humanReadableText, std::unique_ptr<ZgramIterator> &&query, size_t pageSize, size_t queryMargin,
       std::pair<ZgramId, ZgramId> displayed_);
   DISALLOW_COPY_AND_ASSIGN(Subscription);
   DISALLOW_MOVE_COPY_AND_ASSIGN(Subscription);
@@ -114,6 +114,8 @@ public:
 
   subscriptionId_t id() const { return id_; }
   const std::shared_ptr<Profile> &profile() const { return profile_; }
+
+  const std::string &humanReadableText() const { return humanReadableText_; }
 
   const ZgramIterator *query() const { return query_.get(); }
 
@@ -133,6 +135,7 @@ private:
   subscriptionId_t id_;
   // The profile of the logged-in user.
   std::shared_ptr<Profile> profile_;
+  std::string humanReadableText_;
   std::unique_ptr<ZgramIterator> query_;
   size_t pageSize_ = 0;
   size_t queryMargin_ = 0;

--- a/backend/include/public/z2kplus/backend/reverse_index/iterators/zgram/not.h
+++ b/backend/include/public/z2kplus/backend/reverse_index/iterators/zgram/not.h
@@ -26,6 +26,16 @@ public:
   ~Not() final;
 
   std::unique_ptr<ZgramIteratorState> createState(const IteratorContext &ctx) const final;
+  /**
+   * Fills the 'result' buffer with up to 'capacity' zgramRel_t matching items, where the items so added
+   * are beyond both the previously-returned items and >= 'lowerBound'.
+   * @param ctx Global iterator context, like access to the index and whether the iterator is forward or backwards
+   * @param state This iterator's local state
+   * @param lowerBound Lower bound for returned results
+   * @param result The result buffer
+   * @param capacity The capacity of the result buffer
+   * @return Number of items actually found
+   */
   size_t getMore(const IteratorContext &ctx, ZgramIteratorState *state, zgramRel_t lowerBound,
       zgramRel_t *result, size_t capacity) const final;
 

--- a/backend/src/coordinator/coordinator.cc
+++ b/backend/src/coordinator/coordinator.cc
@@ -101,10 +101,10 @@ void Coordinator::subscribe(std::shared_ptr<Profile> profile, drequests::Subscri
   std::shared_ptr<Subscription> sub;
   {
     FailRoot fr;
-    auto queryRef = trim(req.query());
-    if (!parsing::parse(queryRef, true, &query, fr.nest(HERE)) ||
-        !Subscription::tryCreate(index_, std::move(profile), std::move(query), req.start(), req.pageSize(),
-            req.queryMargin(), &sub, fr.nest(HERE))) {
+    std::string queryText(trim(req.query()));
+    if (!parsing::parse(queryText, true, &query, fr.nest(HERE)) ||
+        !Subscription::tryCreate(index_, std::move(profile), std::move(queryText), std::move(query), req.start(),
+            req.pageSize(), req.queryMargin(), &sub, fr.nest(HERE))) {
       responses->emplace_back(nullptr, dresponses::AckSubscribe(false, toString(fr), Estimates()));
       *possibleNewSub = nullptr;
       return;

--- a/backend/src/coordinator/subscription.cc
+++ b/backend/src/coordinator/subscription.cc
@@ -91,7 +91,7 @@ std::ostream &operator<<(std::ostream &s, const PerSideStatus &o) {
 }
 
 bool Subscription::tryCreate(const ConsolidatedIndex &index, std::shared_ptr<Profile> profile,
-    std::unique_ptr<ZgramIterator> &&query, const SearchOrigin &start, size_t pageSize,
+    std::string humanReadableText, std::unique_ptr<ZgramIterator> &&query, const SearchOrigin &start, size_t pageSize,
     size_t queryMargin, std::shared_ptr<Subscription> *result,
     const FailFrame &/*ff*/) {
   struct visitor_t {
@@ -122,16 +122,17 @@ bool Subscription::tryCreate(const ConsolidatedIndex &index, std::shared_ptr<Pro
   auto displayed = std::make_pair(v.zgramId_, v.zgramId_);
 
   subscriptionId_t id(nextFreeSubscriptionId++);
-  auto res = std::make_shared<Subscription>(Private(), id, std::move(profile), std::move(query),
-      pageSize, queryMargin, std::move(displayed));
+  auto res = std::make_shared<Subscription>(Private(), id, std::move(profile), std::move(humanReadableText),
+      std::move(query), pageSize, queryMargin, std::move(displayed));
   res->resetIndex(index);
   *result = std::move(res);
   return true;
 }
 
 Subscription::Subscription(Private, subscriptionId_t id, std::shared_ptr<Profile> &&profile,
-    std::unique_ptr<ZgramIterator> &&query, size_t pageSize, size_t queryMargin,
-    std::pair<ZgramId, ZgramId> displayed) : id_(id), profile_(std::move(profile)), query_(std::move(query)),
+    std::string humanReadableText, std::unique_ptr<ZgramIterator> &&query, size_t pageSize, size_t queryMargin,
+    std::pair<ZgramId, ZgramId> displayed) : id_(id), profile_(std::move(profile)),
+    humanReadableText_(std::move(humanReadableText)), query_(std::move(query)),
     pageSize_(pageSize), queryMargin_(queryMargin), displayed_(std::move(displayed)) {
 }
 Subscription::~Subscription() = default;

--- a/backend/src/reverse_index/iterators/iterator_common.cc
+++ b/backend/src/reverse_index/iterators/iterator_common.cc
@@ -66,8 +66,8 @@ std::pair<wordRel_t, wordRel_t> IteratorContext::getFieldBoundsRel(const ZgramIn
 
 bool ZgramIteratorState::updateNextStart(const IteratorContext &ctx, zgramRel_t lowerBound,
     size_t capacity) {
-  auto newNextsStart = std::max(nextStart_, lowerBound);
-  nextStart_ = newNextsStart;
+  auto newNextStart = std::max(nextStart_, lowerBound);
+  nextStart_ = newNextStart;
   if (capacity == 0) {
     return false;
   }


### PR DESCRIPTION
This explanation is slightly complicated but the way the 'not' iterator works is it calls its underlying iterator, and returns every value that the underlying iterator does not return.
When the underlying iterator reached exhaustion, the 'not' iterator was storing the 'end' index as a sentinel exhaustion value. Unfortunately, when the next message arrived, the 'not' logic would assume that sentinel value was a legit result of the underlying iterator and then skip over it.

Example:
"not instance:graffiti"

Message 1000 arrives having instance graffiti.
Underlying iterator matches it so we return nothing.
Advances to the next value 1001.
1001 is the end of (current) database, so we store that as a sentinel.

Later, message 1001 arrives, *not* having instance graffiti.
'not' logic sees cached value of 1001, assumes the underlying value *does* have instance graffiti, so incorrectly skips over it.