### PR TITLE
"or" logic was catastrophically wrong.

### DIFF
--- a/backend/src/reverse_index/iterators/iterator_common.cc
+++ b/backend/src/reverse_index/iterators/iterator_common.cc
@@ -102,10 +102,10 @@ Iterator myLowerBound(Iterator begin, Iterator end, const Key &key) {
     }
     ++begin;
   }
-  // Another common case is that the item will not be found
-  // The element to be found is at the last item or before if end[-1] >= key
-  // Otherwise it is later. So exit if !(end[-1] >= key)
-  // aka: end[-1] < key
+  // Another common case is that the item does not exist.
+  // If end[-1] >= key then the element might be found (somewhere).
+  // Otherwise (if end[-1] < key) the element does not exist.
+  // If the latter is the case, then exit.
   if (begin == end || end[-1] < key) {
     return end;
   }


### PR DESCRIPTION
The problem is that the "or" iterator terminated when *any* of its sub-iterators terminated.
The correct behavior is to terminate when *all* of them have terminated.

Fixes https://github.com/kosak/z2kplus/issues/19
