### PR TITLE
Highlight background of the zgram being hovered over

### DIFF
--- a/frontend/client/components/zgram_body_component.ts
+++ b/frontend/client/components/zgram_body_component.ts
@@ -30,7 +30,7 @@ export const zgramBodyComponent = {
         <button type="button" class="btn btn-warning btn-sm" @click="zg.overrideWeaklyHidden()">Show</button>
       </div>
       <div v-else v-html="zg.bodyAsHtml" @click="zg.doClick()"
-           :class="{zgramUnreadBody: zg.isUnread}">
+           :class="{zgramHoveringBody: zg.isHovering, zgramUnreadBody: !zg.isHovering && zg.isUnread}">
       </div>
     `
 }

--- a/frontend/client/static/chat.html
+++ b/frontend/client/static/chat.html
@@ -81,6 +81,10 @@
             background-color: #fff1a8;
         }
 
+        .zgramHoveringBody {
+            background-color: #f0f0f0;
+        }
+
         .zgramActions {
             font-family: 'Source Sans Pro', sans-serif;
             font-size: 0.85em;

--- a/frontend/client/viewmodels/zgram_viewmodel.ts
+++ b/frontend/client/viewmodels/zgram_viewmodel.ts
@@ -419,6 +419,10 @@ export class ZgramViewModel {
         return lastRead === undefined || this.zgramId.raw > lastRead.raw;
     }
 
+    get isHovering() {
+        return this.state.currentlyHoveringZgram === this;
+    }
+
     maybeUpdateMathJax(el: any) {
         if (this.isMarkdeepText) {
             this.state.renderer.updateMathJax(this.body, el);


### PR DESCRIPTION
This should make it easier to see what zgram will be affected by the 'r' (reply-to) hotkey.

For now this addresses https://github.com/kosak/z2kplus/issues/5
